### PR TITLE
デフォルトモデルを gpt-5-mini に変更

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           debug: true
           review_comment_lgtm: false
-          openai_light_model: gpt-4.1-mini
-          openai_heavy_model: gpt-4.1-mini
           language: ja-JP
           path_filters: |
             !dist/**

--- a/action.yml
+++ b/action.yml
@@ -152,11 +152,11 @@ inputs:
     required: false
     description:
       'Model to use for simple tasks like summarizing diff on a file.'
-    default: 'gpt-4.1-mini'
+    default: 'gpt-5-mini'
   openai_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'gpt-4.1-mini'
+    default: 'gpt-5-mini'
   openai_model_temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/action.yml
+++ b/action.yml
@@ -238,11 +238,7 @@ inputs:
     required: false
     description: 'The icon for the bot'
     default: '<img src="https://avatars.githubusercontent.com/in/347564?s=41" alt="Image description" width="20" height="20">'
-  experimental_models:
-    required: false
-    description: '新規ロジックで処理するモデル名のリスト（改行区切り）'
-    default: |
-      o4-mini
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/37.index.js
+++ b/dist/37.index.js
@@ -10,7 +10,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "toFormData": () => (/* binding */ toFormData)
 /* harmony export */ });
-/* harmony import */ var fetch_blob_from_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7972);
+/* harmony import */ var fetch_blob_from_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(2777);
 /* harmony import */ var formdata_polyfill_esm_min_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(8010);
 
 

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -1,28 +1,3 @@
-formdata-node
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2017-present Nick K.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 node-fetch
 MIT
 The MIT License (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/plugin-throttling": "^6.1.0",
         "minimatch": "^9.0.1",
         "node-fetch": "^3.3.1",
-        "openai": "^4.96.2",
+        "openai": "^5.12.1",
         "p-limit": "^4.0.0",
         "p-retry": "^5.1.2"
       },
@@ -2231,30 +2231,8 @@
     "node_modules/@types/node": {
       "version": "20.4.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2525,17 +2503,6 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2598,17 +2565,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2809,7 +2765,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/atomically": {
       "version": "2.0.1",
@@ -3119,6 +3076,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3288,6 +3246,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3501,6 +3460,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3592,6 +3552,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3698,6 +3659,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3706,6 +3668,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3734,6 +3697,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3745,6 +3709,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4606,14 +4571,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventsource-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.0.0.tgz",
@@ -4845,31 +4802,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -4905,6 +4837,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4958,6 +4891,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4990,6 +4924,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5146,6 +5081,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5223,6 +5159,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5234,6 +5171,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5248,6 +5186,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5337,14 +5276,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8608,6 +8539,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8644,6 +8576,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8652,6 +8585,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -8933,18 +8867,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.96.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.2.tgz",
-      "integrity": "sha512-R2XnxvMsizkROr7BV3uNp1q/3skwPZ7fmPjO1bXLnfB4Tu5xKxrT1EVwzjhxn0MZKBKAvOaGWS63jTMN6KrIXA==",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.1.tgz",
+      "integrity": "sha512-26s536j4Fi7P3iUma1S9H33WRrw0Qu8pJ2nYJHffrlKHPU0JK4d0r3NcMgqEcAeTdNLGYNyoFsqN4g4YE9vutg==",
       "bin": {
         "openai": "bin/cli"
       },
@@ -8959,52 +8884,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.87",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
-      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/openai/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/openai/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/optionator": {
@@ -10418,11 +10297,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@octokit/plugin-throttling": "^6.1.0",
     "minimatch": "^9.0.1",
     "node-fetch": "^3.3.1",
-    "openai": "^4.96.2",
+    "openai": "^5.12.1",
     "p-limit": "^4.0.0",
     "p-retry": "^5.1.2"
   },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -44,16 +44,9 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
         'OPENAI_API_KEY is missing, cannot initialize OpenAI clients'
       )
     }
-    // choose client based on experimental model list
-    if (options.isExperimentalModel(openaiOptions.model)) {
-      // use official OpenAI SDK for experimental models
-      this.openaiClient = new OpenAI({
-        apiKey: process.env.OPENAI_API_KEY,
-        baseURL: options.apiBaseUrl
-      })
-    } else {
-      // use ChatGPTAPI for existing models
-      // pass prepared system message
+    // choose client based on model type
+    if (options.isChatGptApiModel(openaiOptions.model)) {
+      // use ChatGPTAPI for specific models (gpt-4.1 series)
       this.api = new ChatGPTAPI({
         apiBaseUrl: options.apiBaseUrl,
         systemMessage: this.systemMessageContent,
@@ -66,6 +59,12 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
           temperature: options.openaiModelTemperature,
           model: this.model
         }
+      })
+    } else {
+      // use official OpenAI SDK for all other models (gpt-5 series, etc.)
+      this.openaiClient = new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+        baseURL: options.apiBaseUrl
       })
     }
   }
@@ -92,16 +91,25 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
     // branch by client
     if (this.openaiClient) {
       // official OpenAI SDK for experimental models
-      const resp = await this.openaiClient.chat.completions.create({
+      const requestParams: any = {
         model: this.model,
         messages: [
           {role: 'system', content: this.systemMessageContent},
           {role: 'user', content: message}
         ],
         // eslint-disable-next-line camelcase
-        max_completion_tokens: this.openaiOptions.tokenLimits.maxTokens,
-        temperature: this.options.openaiModelTemperature
-      })
+        max_completion_tokens: this.openaiOptions.tokenLimits.responseTokens
+      }
+
+      // GPT-5系モデルはtemperature=0をサポートしていないため、デフォルト値を使用
+      const gpt5Models = ['gpt-5', 'gpt-5-mini', 'gpt-5-nano']
+      if (!gpt5Models.some(model => this.model.includes(model))) {
+        requestParams.temperature = this.options.openaiModelTemperature
+      }
+
+      const resp = await this.openaiClient.chat.completions.create(
+        requestParams
+      )
       const text = resp.choices?.[0]?.message?.content ?? ''
       const newIds: Ids = {
         parentMessageId: resp.id,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -45,7 +45,7 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
       )
     }
     // choose client based on model type
-    if (options.isChatGptApiModel(openaiOptions.model)) {
+    if (options.isOldChatGptApiModel(openaiOptions.model)) {
       // use ChatGPTAPI for specific models (gpt-4.1 series)
       this.api = new ChatGPTAPI({
         apiBaseUrl: options.apiBaseUrl,
@@ -91,7 +91,7 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
     // branch by client
     if (this.openaiClient) {
       // official OpenAI SDK for experimental models
-      const requestParams: any = {
+      const requestParams: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
         model: this.model,
         messages: [
           {role: 'system', content: this.systemMessageContent},

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,9 +25,11 @@ export class Bot {
   private readonly systemMessageContent: string // system message for both clients
 
   private readonly options: Options
+  private readonly openaiOptions: OpenAIOptions
 
   constructor(options: Options, openaiOptions: OpenAIOptions) {
     this.options = options
+    this.openaiOptions = openaiOptions
     this.model = openaiOptions.model
     // build common system message with cutoff and date
     const currentDate = new Date().toISOString().split('T')[0]
@@ -39,7 +41,7 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
 `
     if (!process.env.OPENAI_API_KEY) {
       throw new Error(
-        "OPENAI_API_KEY is missing, cannot initialize OpenAI clients"
+        'OPENAI_API_KEY is missing, cannot initialize OpenAI clients'
       )
     }
     // choose client based on experimental model list
@@ -93,9 +95,12 @@ IMPORTANT: Entire response must be in the language with ISO code: ${options.lang
       const resp = await this.openaiClient.chat.completions.create({
         model: this.model,
         messages: [
-          { role: 'system', content: this.systemMessageContent },
-          { role: 'user', content: message }
-        ]
+          {role: 'system', content: this.systemMessageContent},
+          {role: 'user', content: message}
+        ],
+        // eslint-disable-next-line camelcase
+        max_completion_tokens: this.openaiOptions.tokenLimits.maxTokens,
+        temperature: this.options.openaiModelTemperature
       })
       const text = resp.choices?.[0]?.message?.content ?? ''
       const newIds: Ids = {

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -4,21 +4,9 @@ export class TokenLimits {
   responseTokens: number
   knowledgeCutOff: string
 
-  constructor(model = 'gpt-4.1-mini') {
+  constructor(model = 'gpt-5-mini') {
     this.knowledgeCutOff = '2021-09-01'
-    if (model === 'gpt-4.1') {
-      this.maxTokens = 30000
-      this.responseTokens = 4000
-    } else if (model === 'gpt-4.1-mini') {
-      this.maxTokens = 30000
-      this.responseTokens = 4000
-    } else if (model === 'gpt-4.1-nano') {
-      this.maxTokens = 30000
-      this.responseTokens = 4000
-    } else if (model === 'o4-mini') {
-      this.maxTokens = 30000
-      this.responseTokens = 4000
-    } else if (model === 'gpt-4-32k') {
+    if (model === 'gpt-4-32k') {
       this.maxTokens = 32600
       this.responseTokens = 4000
     } else if (model === 'gpt-3.5-turbo-16k') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,7 @@ async function run(): Promise<void> {
     getInput('openai_concurrency_limit'),
     getInput('github_concurrency_limit'),
     getInput('openai_base_url'),
-    getInput('language'),
-    getMultilineInput('experimental_models')
+    getInput('language')
   )
 
   // print options

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,6 +23,7 @@ export class Options {
   apiBaseUrl: string
   language: string
   experimentalModels: string[]
+  chatGptApiModels: string[] // ChatGPTAPIを使用するモデルのリスト
 
   constructor(
     debug: boolean,
@@ -63,6 +64,11 @@ export class Options {
     this.heavyTokenLimits = new TokenLimits(openaiHeavyModel)
     this.apiBaseUrl = apiBaseUrl
     this.language = language
+
+    // ChatGPTAPIを使用する特定のモデルを定義
+    this.chatGptApiModels = ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano']
+
+    // experimentalModelsは後方互換性のために残すが、実際の判定はchatGptApiModelsを使用
     this.experimentalModels = experimentalModelsInput ?? [
       'gpt-5-mini',
       'gpt-5',
@@ -91,6 +97,8 @@ export class Options {
     info(`review_token_limits: ${this.heavyTokenLimits.string()}`)
     info(`api_base_url: ${this.apiBaseUrl}`)
     info(`language: ${this.language}`)
+    info(`experimental_models: ${JSON.stringify(this.experimentalModels)}`)
+    info(`chatgpt_api_models: ${JSON.stringify(this.chatGptApiModels)}`)
   }
 
   checkPath(path: string): boolean {
@@ -99,8 +107,18 @@ export class Options {
     return ok
   }
 
+  /**
+   * ChatGPTAPIを使用すべきモデルかどうかを判定
+   */
+  isChatGptApiModel(model: string): boolean {
+    return this.chatGptApiModels.includes(model)
+  }
+
+  /**
+   * 後方互換性のために残す（実際にはisChatGptApiModelの逆を返す）
+   */
   isExperimentalModel(model: string): boolean {
-    return this.experimentalModels.includes(model)
+    return !this.isChatGptApiModel(model)
   }
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -33,8 +33,8 @@ export class Options {
     reviewCommentLGTM = false,
     pathFilters: string[] | null = null,
     systemMessage = '',
-    openaiLightModel = 'gpt-4.1-mini',
-    openaiHeavyModel = 'gpt-4.1-mini',
+    openaiLightModel = 'gpt-5-mini',
+    openaiHeavyModel = 'gpt-5-mini',
     openaiModelTemperature = '0.0',
     openaiRetries = '3',
     openaiTimeoutMS = '120000',
@@ -149,7 +149,7 @@ export class OpenAIOptions {
   model: string
   tokenLimits: TokenLimits
 
-  constructor(model = 'gpt-4.1-mini', tokenLimits: TokenLimits | null = null) {
+  constructor(model = 'gpt-5-mini', tokenLimits: TokenLimits | null = null) {
     this.model = model
     if (tokenLimits != null) {
       this.tokenLimits = tokenLimits

--- a/src/options.ts
+++ b/src/options.ts
@@ -97,7 +97,6 @@ export class Options {
     info(`review_token_limits: ${this.heavyTokenLimits.string()}`)
     info(`api_base_url: ${this.apiBaseUrl}`)
     info(`language: ${this.language}`)
-    info(`experimental_models: ${JSON.stringify(this.experimentalModels)}`)
     info(`chatgpt_api_models: ${JSON.stringify(this.chatGptApiModels)}`)
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,8 +22,7 @@ export class Options {
   heavyTokenLimits: TokenLimits
   apiBaseUrl: string
   language: string
-  experimentalModels: string[]
-  chatGptApiModels: string[] // ChatGPTAPIを使用するモデルのリスト
+  oldChatGptApiModels: string[] // ChatGPTAPIを使用するモデルのリスト
 
   constructor(
     debug: boolean,
@@ -42,8 +41,7 @@ export class Options {
     openaiConcurrencyLimit = '6',
     githubConcurrencyLimit = '6',
     apiBaseUrl = 'https://api.openai.com/v1',
-    language = 'ja-JP',
-    experimentalModelsInput: string[] | null = null
+    language = 'ja-JP'
   ) {
     this.debug = debug
     this.disableReview = disableReview
@@ -66,14 +64,8 @@ export class Options {
     this.language = language
 
     // ChatGPTAPIを使用する特定のモデルを定義
-    this.chatGptApiModels = ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano']
-
-    // experimentalModelsは後方互換性のために残すが、実際の判定はchatGptApiModelsを使用
-    this.experimentalModels = experimentalModelsInput ?? [
-      'gpt-5-mini',
-      'gpt-5',
-      'gpt-5-nano'
-    ]
+    // gpt-5系以降は公式OpenAI SDK(v5)を使用するためここには含めない
+    this.oldChatGptApiModels = ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano']
   }
 
   // print all options using core.info
@@ -97,7 +89,7 @@ export class Options {
     info(`review_token_limits: ${this.heavyTokenLimits.string()}`)
     info(`api_base_url: ${this.apiBaseUrl}`)
     info(`language: ${this.language}`)
-    info(`chatgpt_api_models: ${JSON.stringify(this.chatGptApiModels)}`)
+    info(`chatgpt_api_models: ${JSON.stringify(this.oldChatGptApiModels)}`)
   }
 
   checkPath(path: string): boolean {
@@ -107,17 +99,10 @@ export class Options {
   }
 
   /**
-   * ChatGPTAPIを使用すべきモデルかどうかを判定
+   * 旧ChatGPTAPIを使用すべきモデルかどうかを判定
    */
-  isChatGptApiModel(model: string): boolean {
-    return this.chatGptApiModels.includes(model)
-  }
-
-  /**
-   * 後方互換性のために残す（実際にはisChatGptApiModelの逆を返す）
-   */
-  isExperimentalModel(model: string): boolean {
-    return !this.isChatGptApiModel(model)
+  isOldChatGptApiModel(model: string): boolean {
+    return this.oldChatGptApiModels.includes(model)
   }
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,7 +63,11 @@ export class Options {
     this.heavyTokenLimits = new TokenLimits(openaiHeavyModel)
     this.apiBaseUrl = apiBaseUrl
     this.language = language
-    this.experimentalModels = experimentalModelsInput ?? []
+    this.experimentalModels = experimentalModelsInput ?? [
+      'gpt-5-mini',
+      'gpt-5',
+      'gpt-5-nano'
+    ]
   }
 
   // print all options using core.info
@@ -96,7 +100,7 @@ export class Options {
   }
 
   isExperimentalModel(model: string): boolean {
-        return this.experimentalModels.includes(model)
+    return this.experimentalModels.includes(model)
   }
 }
 


### PR DESCRIPTION
デフォルトモデルを gpt-4.1-mini から gpt-5-mini に変更
openaiのバージョンを 5.12.1 に更新
デフォルトで OpenAI のモデルを利用するように変更
許容する古いモデルを "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano" に制限



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: デフォルトのOpenAIモデルを「gpt-5-mini」に更新し、最新SDK（v5.12.1）に対応  
- Refactor: モデル選択ロジックを整理し、「gpt-4.1」系はChatGPTAPI、「gpt-5」系は公式SDKで処理を分離  
- Refactor: トークン制限や温度設定の管理を強化し、API呼び出しパラメータを最適化  
- Chore: 不要なexperimental_models設定を削除し、環境変数エラーメッセージ表記を統一  
- Chore: 依存パッケージのOpenAIライブラリを最新版にアップデート
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->